### PR TITLE
Changing error message in addByPath function to show the bundlePath rather than the path object

### DIFF
--- a/bundles/generic/views/list.jade
+++ b/bundles/generic/views/list.jade
@@ -12,7 +12,7 @@ p Nullam in dui mauris. Vivamus hendrerit arcu sed erat molestie vehicula. Sed a
 include includes/list-actions
 
 .panel-list
-	h3 All Administrators
+	h3 All #{crudDelegate.plural}
 
 	include includes/filter-form
 	include includes/filter-summary

--- a/lib/bundled/bundleManager.js
+++ b/lib/bundled/bundleManager.js
@@ -24,7 +24,7 @@ module.exports.createBundleManager = function(serviceLocator) {
 			bundle.path = path.dirname(bundlePath);
 			add(bundle);
 		} else {
-			throw new Error('Unable to find bundle:' + path);
+			throw new Error('Unable to find bundle:' + bundlePath);
 		}
 	}
 


### PR DESCRIPTION
To help with debugging purposes
