### PR TITLE
Fixed date format of dateTime viewhelper

### DIFF
--- a/viewHelpers/global.js
+++ b/viewHelpers/global.js
@@ -26,7 +26,7 @@ module.exports.createHelpers = function(properties, app) {
 			})
 			.helpers({
 				dateTime: function(date) {
-					return (new Date(date)).format('d mmm yyyy @ H:m:s');
+					return (new Date(date)).format('d mmm yyyy @ H:MM:ss');
 				},
 				date: function(date) {
 					var d = new Date(date);


### PR DESCRIPTION
Currently the dateTime view helper used on generic list and view is outputting the date in the following format:

8 Jan 2012 @ 18:1:16

Fixed this to show the correct minutes and seconds.
