### PR TITLE
Fixing bug in search query builder

### DIFF
--- a/bundles/generic/views/list.jade
+++ b/bundles/generic/views/list.jade
@@ -58,8 +58,8 @@ include includes/list-actions
 											td=booleanFormatter(entity[key])
 										- else if (propertyMeta.type === 'file')
 											td.thumbnail
-											- if (entity[key])
-												mixin displayImage(100, 100, entity[key][0], crudDelegate.name + ' - ' + entityName, 'crop')
+												- if (entity[key])
+													mixin displayImage(100, 100, entity[key][0], crudDelegate.name + ' - ' + entityName, 'crop')
 										- else if (propertyMeta.type === 'link')
 											td
 												a(href=entity[key], target='_blank')=entity[key]

--- a/lib/utils/buildSearchQuery.js
+++ b/lib/utils/buildSearchQuery.js
@@ -13,7 +13,6 @@ module.exports.createSearchQueryBuilder = function(searchProperties, logger, ser
 
 		if (Object.keys(searchProperties).length === 0) {
 			logger.warn('No search fields set up for ' + serviceName);
-			return query;
 		}
 
 		if (filter) {


### PR DESCRIPTION
When the search query builder became route middleware, not all of the return statements were remove. This was causing the function to return before next() is called if no search properties are setup

Also fixing indentation on list view for images.
