### PR TITLE
#38: generic: Fix selection of title field

### DIFF
--- a/bundles/generic/lib/genericAdminViewSchema.js
+++ b/bundles/generic/lib/genericAdminViewSchema.js
@@ -8,9 +8,18 @@ module.exports.createViewSchema = function(schema) {
 		});
 	});
 	// Ensure that this schema has a valid title property to display.
-	//TODO: This should look for the first property that is visible in all views.
 	if ((schema.title === undefined) || (schema.groups[0].properties[schema.title] === undefined)) {
-		schema.title = Object.keys(schema.groups[0].properties)[0];
+		Object.keys(schema.groups[0].properties).forEach(function (key) {
+			if (schema.title === undefined) {
+				var property = schema.groups[0].properties[key];
+				if (property.type !== 'hidden' && property.view === true) {
+					schema.title = key;
+				}
+			}
+		});
+		if (schema.title === undefined) {
+			throw new Error(schema.groups[0].name + " view schema has no properties which can be used as the object title");
+		}
 	}
 	return schema;
 };

--- a/bundles/generic/lib/genericAdminViewSchema.js
+++ b/bundles/generic/lib/genericAdminViewSchema.js
@@ -12,7 +12,7 @@ module.exports.createViewSchema = function(schema) {
 		Object.keys(schema.groups[0].properties).forEach(function (key) {
 			if (schema.title === undefined) {
 				var property = schema.groups[0].properties[key];
-				if (property.type !== 'hidden' && property.view === true) {
+				if (property.type !== 'hidden' && property.type !== 'password' && property.view === true) {
 					schema.title = key;
 				}
 			}

--- a/bundles/generic/test/genericAdminViewSchema.test.js
+++ b/bundles/generic/test/genericAdminViewSchema.test.js
@@ -1,0 +1,86 @@
+var
+	genericAdminViewSchema = require('../lib/genericAdminViewSchema'),
+	should = require('should');
+
+describe('genericAdminViewSchema', function () {
+	describe('#createViewSchema()', function () {
+		it('should not select a hidden field as the object\'s title field', function () {
+			var schema = {
+				groups: [{
+					name: 'Test',
+					description: 'This schema is a subset of what appears in the administrator bundle',
+					properties: {
+						_id: {type: 'hidden', view: true} 
+					}
+				}]
+			};
+
+			(function(){
+				genericAdminViewSchema.createViewSchema(schema);
+			}).should.throw();
+		});
+
+		it('should not select a password field as the object\'s title field', function () {
+			var schema = {
+				groups: [{
+					name: 'Test',
+					description: 'This schema is a subset of what appears in the administrator bundle',
+					properties: {
+						password: {type: 'password', view: true} 
+					}
+				}]
+			};
+
+			(function(){
+				genericAdminViewSchema.createViewSchema(schema);
+			}).should.throw();
+		});
+
+		it('should not select a field with view marked false as the object\'s title field', function () {
+			var schema = {
+				groups: [{
+					name: 'Test',
+					description: 'This schema is a subset of what appears in the administrator bundle',
+					properties: {
+						middleInitial: {view: false} 
+					}
+				}]
+			};
+
+			(function(){
+				genericAdminViewSchema.createViewSchema(schema);
+			}).should.throw();
+		});
+
+		it('should select the first field with no type and view marked true as the object\'s title field', function () {
+			var schema = {
+				groups: [{
+					name: 'Test',
+					description: 'This schema is a subset of what appears in the administrator bundle',
+					properties: {
+						firstName: {view: true},
+						lastName: {view: true}
+					}
+				}]
+			};
+			genericAdminViewSchema.createViewSchema(schema).title.should.equal('firstName');
+		});
+
+		it('should not override the title if the user has provided one', function () {
+			var schema = {
+				groups: [{
+					name: 'Test',
+					description: 'This schema is a subset of what appears in the administrator bundle',
+					properties: {
+						firstName: {},
+						middleInitial: {},
+						lastName: {}
+					}
+				}],
+				title: 'lastName'
+			};
+			genericAdminViewSchema.createViewSchema(schema).title.should.equal('lastName');
+		});
+
+	});
+});


### PR DESCRIPTION
Attached code changes generic's behaviour so that it will not try to use a hidden or password field as the title field for a view schema.

Mocha tests covering the changes have been added to the generic bundle.
