### PR TITLE
Mixin for datepicker field and generic viewSchema 'date' support

### DIFF
--- a/bundles/generic/views/form.jade
+++ b/bundles/generic/views/form.jade
@@ -2,57 +2,59 @@ include ../../../views/mixins/formFields
 include ../../../views/mixins/file
 
 h1
-	-if (page.action == 'create')
-		| New #{crudDelegate.name}
-	-else
-		| Edit #{crudDelegate.name}
+  -if (page.action == 'create')
+    | New #{crudDelegate.name}
+  -else
+    | Edit #{crudDelegate.name}
 
 nav.breadcrumb
-	ul
-		li.nav-home: a(href='/admin') Home
-		li: a(href='/admin/#{crudDelegate.urlName}') #{crudDelegate.plural}
-		li
-			-if (page.action == 'create')
-				| New #{crudDelegate.name}
-			-else
-				| Edit #{crudDelegate.name}
+  ul
+    li.nav-home: a(href='/admin') Home
+    li: a(href='/admin/#{crudDelegate.urlName}') #{crudDelegate.plural}
+    li
+      -if (page.action == 'create')
+        | New #{crudDelegate.name}
+      -else
+        | Edit #{crudDelegate.name}
 
 -if (page.action == 'update')
-	include includes/form-actions
+  include includes/form-actions
 
 form(method='post', enctype='multipart/form-data')
-	- if (Object.keys(errors).length > 0)
-		.notification.error
-			h4 Please check the form and try again
-			- each error in unshownErrors
-				p= errors[error]
-	- each group in viewSchema.groups
-		fieldset
-			- if (typeof group.name !== 'undefined')
-				h3=group.name
-			- if (typeof group.description !== 'undefined')
-				p.group-description=group.description
-			- each propertyMeta, key in group.properties
-				- if (propertyMeta[formType])
-					- var name = crudDelegate.entityDelegate.propertyName(key)
-					- if ([undefined, 'url'].indexOf(propertyMeta.type) !== -1 || propertyMeta.type === 'link')
-						mixin textFieldForObject({ name: key }, { label: name, data: entity, required: propertyMeta.required, errors: errors, information: propertyMeta.info})
-					- if (propertyMeta.type === 'dropdown')
-						mixin dropdownForObject({ name: key }, { label: name, data: entity, required: propertyMeta.required, errors: errors, list: propertyMeta.options, information: propertyMeta.info})
-					- if (propertyMeta.type === 'multiselect')
-						mixin checkBoxGroupForObject({ name: key }, { label: name, data: entity, required: propertyMeta.required, list: propertyMeta.options, errors: errors, information: propertyMeta.info})
-					- if (propertyMeta.type === 'groupedMultiselect')
-						mixin groupedCheckBoxGroupForObject({ name: key }, { label: name, data: entity, required: propertyMeta.required, groups: propertyMeta.options, errors: errors, information: propertyMeta.info})
-					- if (propertyMeta.type === 'textbox')
-						mixin textboxFieldForObject({ name: key }, { label: name, data: entity, required: propertyMeta.required, errors: errors, information: propertyMeta.info})
-					- if (propertyMeta.type === 'checkbox')
-						mixin checkboxFieldForObject({ name: key }, { label: name, data: entity, required: propertyMeta.required, errors: errors, information: propertyMeta.info})
-					- if (propertyMeta.type === 'file')
-						mixin fileFieldForObject({ name: key }, { label: name, data: entity, required: propertyMeta.required, errors: errors, information: propertyMeta.info})
-					- if (propertyMeta.type === 'hidden')
-						input(type='hidden', name=key, value=entity[key])
-					- if (propertyMeta.type === 'password')
-						mixin passwordFieldForObject({ name: key }, { label: name, data: entity, required: propertyMeta.required, errors: errors, information: propertyMeta.info})
-	fieldset.actions
-		a.button(href='/admin/#{crudDelegate.urlName}') Cancel
-		input.button.primary(type='submit',value='Submit')
+  - if (Object.keys(errors).length > 0)
+    .notification.error
+      h4 Please check the form and try again
+      - each error in unshownErrors
+        p= errors[error]
+  - each group in viewSchema.groups
+    fieldset
+      - if (typeof group.name !== 'undefined')
+        h3=group.name
+      - if (typeof group.description !== 'undefined')
+        p.group-description=group.description
+      - each propertyMeta, key in group.properties
+        - if (propertyMeta[formType])
+          - var name = crudDelegate.entityDelegate.propertyName(key)
+          - if ([undefined, 'url'].indexOf(propertyMeta.type) !== -1 || propertyMeta.type === 'link')
+            mixin textFieldForObject({ name: key }, { label: name, data: entity, required: propertyMeta.required, errors: errors, information: propertyMeta.info})
+          - if (propertyMeta.type === 'dropdown')
+            mixin dropdownForObject({ name: key }, { label: name, data: entity, required: propertyMeta.required, errors: errors, list: propertyMeta.options, information: propertyMeta.info})
+          - if (propertyMeta.type === 'multiselect')
+            mixin checkBoxGroupForObject({ name: key }, { label: name, data: entity, required: propertyMeta.required, list: propertyMeta.options, errors: errors, information: propertyMeta.info})
+          - if (propertyMeta.type === 'groupedMultiselect')
+            mixin groupedCheckBoxGroupForObject({ name: key }, { label: name, data: entity, required: propertyMeta.required, groups: propertyMeta.options, errors: errors, information: propertyMeta.info})
+          - if (propertyMeta.type === 'textbox')
+            mixin textboxFieldForObject({ name: key }, { label: name, data: entity, required: propertyMeta.required, errors: errors, information: propertyMeta.info})
+          - if (propertyMeta.type === 'checkbox')
+            mixin checkboxFieldForObject({ name: key }, { label: name, data: entity, required: propertyMeta.required, errors: errors, information: propertyMeta.info})
+          - if (propertyMeta.type === 'file')
+            mixin fileFieldForObject({ name: key }, { label: name, data: entity, required: propertyMeta.required, errors: errors, information: propertyMeta.info})
+          - if (propertyMeta.type === 'hidden')
+            input(type='hidden', name=key, value=entity[key])
+          - if (propertyMeta.type === 'password')
+            mixin passwordFieldForObject({ name: key }, { label: name, data: entity, required: propertyMeta.required, errors: errors, information: propertyMeta.info})
+          - if (propertyMeta.type === 'date')
+            mixin datepickerFieldForObject({ name: key }, { label: name, data: entity, required: propertyMeta.required, errors: errors, information: propertyMeta.info})
+  fieldset.actions
+    a.button(href='/admin/#{crudDelegate.urlName}') Cancel
+    input.button.primary(type='submit',value='Submit')

--- a/views/mixins/formFields.jade
+++ b/views/mixins/formFields.jade
@@ -96,6 +96,16 @@ mixin textFieldForObject(inputParams, params)
   - inputParams.value = params.data[inputParams.name];
   mixin textField(inputParams, params)
 
+mixin datepickerField(inputParams, params)
+  - inputParams.type = 'text'
+  - inputParams.class = 'datepicker'
+  mixin inputField(inputParams, params)
+
+mixin datepickerFieldForObject(inputParams, params)
+  - params.error = params.errors[inputParams.name];
+  - inputParams.value = params.data[inputParams.name];
+  mixin datepickerField(inputParams, params)
+
 //mixin passwordField(label, name, required, error, maxLength, information, placeholder)
 mixin passwordField(inputParams, params)
   - inputParams.type = 'password'


### PR DESCRIPTION
You can now define dates in the generic.viewSchema, eg:

```
...
startDate: {
  list: true,
  view: true,
  createForm: true,
  updateForm: true,
  type: 'date'
}
...
```

Also, made sure views created by generic have the relevant compact js and tidied up the code a bit.
