### PR TITLE
MongoDbCrudDelegate update patch (for issue 66)

### DIFF
--- a/lib/utils/mongodbCrudDelegate.js
+++ b/lib/utils/mongodbCrudDelegate.js
@@ -130,11 +130,11 @@ module.exports.createMongodbCrudDelegate = function(name, plural, idProperty, co
           if (returnEntity === null) {
             logger.warn('Unable to find ' + name + ' for update with ' + idProperty + ' = ' + id);
             callback(new RangeError('Unable to find ' + name + ' for update with ' + idProperty + ' = ' + id), null);
-	  } else {
-	    logger.info(name + ' updated ', processedEntityObject);
-	    self.emit('onUpdate', returnEntity);
-	    callback(null, returnEntity);
-	  }
+          } else {
+            logger.info(name + ' updated ', processedEntityObject);
+            self.emit('onUpdate', returnEntity);
+            callback(null, returnEntity);
+          }
         } else {
           logger.warn('Error on update', error, returnEntity);
           // Return the same object that was passed in, so the user can see problems.

--- a/lib/utils/mongodbCrudDelegate.js
+++ b/lib/utils/mongodbCrudDelegate.js
@@ -127,9 +127,14 @@ module.exports.createMongodbCrudDelegate = function(name, plural, idProperty, co
       delete processedEntityObject[idProperty];
       collection.findAndModify(query, [[id, 'asc']], { $set : processedEntityObject }, { 'new': true }, function (error, returnEntity) {
         if (error === null) {
-          logger.info(name + ' updated ', processedEntityObject);
-          self.emit('onUpdate', returnEntity);
-          callback(null, returnEntity);
+          if (returnEntity === null) {
+            logger.warn('Unable to find ' + name + ' for update with ' + idProperty + ' = ' + id);
+            callback(new RangeError('Unable to find ' + name + ' for update with ' + idProperty + ' = ' + id), null);
+	  } else {
+	    logger.info(name + ' updated ', processedEntityObject);
+	    self.emit('onUpdate', returnEntity);
+	    callback(null, returnEntity);
+	  }
         } else {
           logger.warn('Error on update', error, returnEntity);
           // Return the same object that was passed in, so the user can see problems.


### PR DESCRIPTION
This patch resolves the problem where an update falsely reports success when it has failed due to a document not being found by its id field.

See: https://github.com/serby/control/issues/66
