### PR TITLE
Fixing delete redirect issue

### DIFF
--- a/bundles/generic/lib/genericAdminRoutes.js
+++ b/bundles/generic/lib/genericAdminRoutes.js
@@ -297,7 +297,7 @@ module.exports.createRoutes = function (app, render, schema, model, serviceLocat
         if (error !== null) {
           res.send(404);
         } else {
-          res.redirect(req.headers.referer);
+          res.redirect('/admin/' + model.urlName);
         }
       });
     }

--- a/bundles/generic/lib/genericAdminRoutes.js
+++ b/bundles/generic/lib/genericAdminRoutes.js
@@ -297,7 +297,7 @@ module.exports.createRoutes = function (app, render, schema, model, serviceLocat
         if (error !== null) {
           res.send(404);
         } else {
-          res.redirect(req.headers.referer);
+          res.redirect('/admin/' + model.urlName + '/');
         }
       });
     }


### PR DESCRIPTION
When using the generic bundle, clicking the delete button while viewing an item tries to redirect itself back to the non-existent item's view page.

Although redirecting back to the section landing page may not always be correct, seems logical for the generic bundle for now.
