### PR TITLE
Removing switch statement and adding page and StatusCode to the Error object

### DIFF
--- a/lib/httpErrorHandler.js
+++ b/lib/httpErrorHandler.js
@@ -1,14 +1,18 @@
-var
-  util = require('util');
+var util = require('util')
+  ;
 
 var NotFound = module.exports.NotFound = function(message) {
   this.name = 'NotFound';
+  this.statusCode = 404;
+  this.page = 'pages/error/404';
   Error.call(this, message);
   Error.captureStackTrace(this, arguments.callee);
 };
 
 var Forbidden = module.exports.Forbidden = function(message) {
   this.name = 'Forbidden';
+  this.statusCode = 403;
+  this.page = 'pages/error/403';
   Error.call(this, message);
   Error.captureStackTrace(this, arguments.callee);
 };
@@ -27,32 +31,21 @@ module.exports.errorHandler = function(serviceLocator, pageTitle) {
   }
 
   return function(error, req, res, next) {
-    var
-      page,
-      statusCode;
 
-    switch(error.name) {
-      case 'NotFound':
-        page = 'pages/error/404';
-        statusCode = 404;
-        break;
-      case 'Forbidden':
-        page = 'pages/error/403';
-        statusCode = 403;
-        break;
-      default:
-        page = 'pages/error/500';
-        statusCode = 500;
-        serviceLocator.logger.error('Unexpected Exception', {
-          stack: error.stack, req: only(['url', 'method', 'body', 'session'], req) });
+    if (typeof error.statusCode === 'undefined') {
+      error.page = 'pages/error/500';
+      error.statusCode = 500;
+      serviceLocator.logger.error('Unexpected Exception', {
+        stack: error.stack, req: only(['url', 'method', 'body', 'session'], req) });
     }
 
     //TODO: Adding JSON accepts handle
-    res.render(page, {
-      status: statusCode,
-      page: {
-        title: pageTitle
+    res.render(error.page,
+      { status: error.statusCode
+      , page:
+        { title: pageTitle
+        }
       }
-    });
+    );
   };
 };


### PR DESCRIPTION
I was finding it difficult to extend httpErrorHandler to provide support for custom Errors.

The proposed change moves the variables `page` and `statusCode` to the Error Object. 
