### PR TITLE
Moved 'bundles to load' out of server.js and into a seperate configuration file

### DIFF
--- a/bundles.json
+++ b/bundles.json
@@ -1,0 +1,12 @@
+[ "home"
+, "generic"
+, "administrator"
+, "admin"
+, "rolesAdmin"
+, "adminUi"
+, "section"
+, "asset"
+, "assetAdmin"
+, "articleAdmin"
+, "article"
+]

--- a/server.js
+++ b/server.js
@@ -5,6 +5,7 @@ module.exports.createServer = function(properties, serviceLocator) {
     , Application = require('./lib/expressApplication')
     , bundled
     , app
+    , bundles = require('./bundles.json')
     , globalViewHelpers = require('./viewHelpers/global')
     , versionator = require('versionator').createBasic('v' + properties.version)
     , compact = require('compact').createCompact({
@@ -27,18 +28,7 @@ module.exports.createServer = function(properties, serviceLocator) {
   serviceLocator.logger.info('Starting \'' + properties.name + '\'');
 
   bundled.addBundles(__dirname + '/bundles/',
-    [ 'home'
-    , 'generic'
-    , 'administrator'
-    , 'admin'
-    , 'rolesAdmin'
-    , 'adminUi'
-    , 'section'
-    , 'asset'
-    , 'assetAdmin'
-    , 'articleAdmin'
-    , 'article'
-    ]
+    bundles
   );
 
   app = Application.createApplication(properties, serviceLocator, sessionDatabaseAdaptor);


### PR DESCRIPTION
I thought it would be a sensible idea to keep this sort of configuration data separate to the actual logic of loading the application
