### PR TITLE
Use bcrypt to hash administrator passwords

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     , "versionator": "~0.1"
     , "winston": "~0.5"
     , "rss": "0.0.3"
+    , "bcrypt": "~0.7"
   }
   , "devDependencies": {
       "mocha": "*"

--- a/properties.js
+++ b/properties.js
@@ -22,6 +22,7 @@ var properties = {
     , name: 'Control-Development'
     }
   , defaultSearchResultSize: 30
+  , bcryptWorkFactor: 9
   , debug: true
 };
 


### PR DESCRIPTION
I set the default work factor to 9, which runs in 0.045 seconds on my machine, roughly 420 times faster than crypto/sha1. This seems like a sane default for most sites.

bcrypt also stores both the work factor and the random salt it generates in the created hash itself, so there's no need to store those separately.
