### PR TITLE
Time out database connection attempts

### DIFF
--- a/lib/database.js
+++ b/lib/database.js
@@ -30,9 +30,16 @@ module.exports.createDatabaseAdaptor = function(properties, serviceLocator) {
 
   function createConnection(callback) {
 
+    var timeout = setTimeout(function() {
+      serviceLocator.logger.error('Database connection attempt timed out', properties.database.name);
+      process.exit(1);
+    }, 10 * 1000);
+
     serviceLocator.logger.info('Connecting to database ' + properties.database.name);
 
     db.open(function(error, connection) {
+      clearTimeout(timeout);
+
       if (error) {
         serviceLocator.logger.error('Error connecting to database', properties.database.name, error);
         if (error === 'connection already opened') {


### PR DESCRIPTION
MongoDB connections attempts now fail after ten seconds, and bring the process down with them.

Should fix #104.
