### PR TITLE
Force no-caching on st, no need for send

### DIFF
--- a/lib/web-stack.js
+++ b/lib/web-stack.js
@@ -6,8 +6,6 @@ var express = require('express')
   , expressValidator = require('express-validator')
   , errorHandler = require('./http-error-handler')
   , st = require('st')
-  , send = require('send')
-  , url = require('url')
 
 module.exports = function createApplication(serviceLocator, databaseAdaptor) {
 
@@ -85,22 +83,35 @@ module.exports = function createApplication(serviceLocator, databaseAdaptor) {
     serviceLocator.logger.verbose('Adding public folder from: ' + bundle.name +
       ' path: ' + bundlePath + '/public - route: ' + publicRoute)
 
-    if (properties.env === 'development') {
-      // In development don't cache static assets. This allows for stylus to be
-      // recompiled and server without restarting node process
-      app.use(function(req, res, next) {
-        var p = url.parse(req.url).pathname
-        if (publicRoute === p.substring(0, publicRoute.length)) {
-          send(req, p.substring(publicRoute.length))
-            .root(bundlePath + '/public').pipe(res)
-        } else {
-          next()
+    var stfn
+
+    if (properties.env !== 'development') {
+      // Use aggressive caching any env that isn't development
+      stfn = st({ path: bundlePath + '/public', url: publicRoute })
+    } else {
+      // In development, cache nothing
+      stfn = st(
+      { path: bundlePath + '/public'
+      , url: publicRoute
+      , cache:
+        { fd: { max: 0, maxAge: 0 }
+        , stat: { max: 0, maxAge: 0 }
+        , content: { max: 0, maxAge: 0 }
         }
       })
-    } else {
-      // For all other envs use st's aggressive default caching
-      app.use(st({ path: bundlePath + '/public', url: publicRoute }))
+
+      // This prevents st from streaming a file from the cache
+      stfn._this.cachedFile = stfn._this.streamFile.bind(stfn._this)
+
     }
+
+    // Override st's default error function and generate
+    // our own 404 for pretty error pages.
+    stfn._this.error = function error(err, res) {
+      serviceLocator.httpErrorHandler(new errorHandler.NotFound(), null, res)
+    }
+
+    app.use(stfn)
   })
 
 

--- a/package.json
+++ b/package.json
@@ -38,8 +38,7 @@
     "validity": "~0.0",
     "versionator": "~0.1",
     "winston": "~0.5",
-    "secure": "*",
-    "send": "~0.1.0"
+    "secure": "*"
   },
   "devDependencies": {
     "mocha": "*",


### PR DESCRIPTION
Setting the caching options on st and patching its own `streamFile()` function onto its `cachedFile()` function mean that nothing gets cached. This means we can use the same module for static assets in all envs.

Also, as a bonus, this patches the `error()` function too, so we get pretty error pages for 404s.
