### PR TITLE
Debug mode

### DIFF
--- a/bundles/admin-ui/bundle.js
+++ b/bundles/admin-ui/bundle.js
@@ -9,50 +9,55 @@ module.exports = {
     items: [
       {
         label: 'Form Elements',
-        url: '#form-elements',
+        url: '/admin/ui#form-elements',
         section: 'admin-ui'
       },
       {
         label: 'Tables',
-        url: '#tables',
+        url: '/admin/ui#tables',
         section: 'admin-ui'
       },
       {
         label: 'Buttons',
-        url: '#buttons',
+        url: '/admin/ui#buttons',
         section: 'admin-ui'
       },
       {
         label: 'Notifications',
-        url: '#notifications',
+        url: '/admin/ui#notifications',
         section: 'admin-ui'
       },
       {
         label: 'Misc UI',
-        url: '#misc-ui',
+        url: '/admin/ui#misc-ui',
         section: 'admin-ui',
         items: [
           {
             label: 'Tooltips',
-            url: '#tooltips',
+            url: '/admin/ui#tooltips',
             section: 'admin-ui'
           },
           {
             label: 'Dialogs',
-            url: '#dialogs',
+            url: '/admin/ui#dialogs',
             section: 'admin-ui'
           },
           {
             label: 'Overlays',
-            url: '#overlays',
+            url: '/admin/ui#overlays',
             section: 'admin-ui'
           },
           {
             label: 'Pagination',
-            url: '#pagination',
+            url: '/admin/ui#pagination',
             section: 'admin-ui'
           }
         ]
+      },
+      {
+        label: 'Debug Mode',
+        url: '/admin/ui/debug',
+        section: 'admin-ui'
       }
     ]
   }],

--- a/bundles/admin-ui/controller.js
+++ b/bundles/admin-ui/controller.js
@@ -22,55 +22,13 @@ module.exports = function createRoutes (serviceLocator, bundleViewPath) {
       });
   });
 
-  serviceLocator.router.get('/admin/ui/form-elements',
+  serviceLocator.router.get('/admin/ui/debug',
     serviceLocator.adminAccessControl.requiredAccess('Admin UI', 'read'),
     serviceLocator.compact.js(['global'], ['admin']),
     function(req, res) {
-      viewRender(req, res, 'form-elements', {
+      viewRender(req, res, 'debug', {
         page: {
-          title: 'Form Elements / Admin UI / ' + serviceLocator.properties.name,
-          section: 'admin-ui'
-        },
-        error: ''
-      });
-  });
-
-  serviceLocator.router.get('/admin/ui/tables',
-    serviceLocator.adminAccessControl.requiredAccess('Admin UI', 'read'),
-    serviceLocator.compact.js(['global'], ['admin']),
-    function(req, res) {
-      viewRender(req, res, 'tables', {
-        page: {
-          title: 'Tables / Admin UI / ' + serviceLocator.properties.name,
-          section: 'admin-ui'
-        },
-        error: ''
-      });
-  });
-
-  serviceLocator.router.get('/admin/ui/grid',
-    serviceLocator.adminAccessControl.requiredAccess('Admin UI', 'read'),
-    serviceLocator.compact.js(['global'], ['admin']),
-    function(req, res) {
-      viewRender(req, res, 'grid', {
-        page: {
-          title: 'Grid / Admin UI / ' + serviceLocator.properties.name,
-          section: 'admin-ui'
-        },
-        error: ''
-      });
-  });
-
-  serviceLocator.router.get('/admin/ui/misc-ui',
-    serviceLocator.adminAccessControl.requiredAccess('Admin UI', 'read'),
-    serviceLocator.compact.js(
-      ['global'],
-      ['admin']
-    ),
-    function(req, res) {
-      viewRender(req, res, 'misc-ui', {
-        page: {
-          title: 'Misc UI Elements / Admin UI / ' + serviceLocator.properties.name,
+          title: 'Debug Mode / Admin UI / ' + serviceLocator.properties.name,
           section: 'admin-ui'
         },
         error: ''

--- a/bundles/admin-ui/views/debug.jade
+++ b/bundles/admin-ui/views/debug.jade
@@ -64,12 +64,12 @@ block content
     section
       h2 Links
 
-      p Links sometimes, though not always, benefit from `title` attributes. Links without are never invalid but it’s a good idea to check.
+      //- p Links sometimes, though not always, benefit from `title` attributes. Links without are never invalid but it’s a good idea to check.
 
-      ul.inline-list
-        li: a(href='#dummy', title='Link Title') Good title attribute
-        li: a(href='#dummy') Missing title attribute
-        li: a(href='#dummy', title='') Empty title attribute
+      //- ul.inline-list
+      //-   li: a(href='#dummy', title='Link Title') Good title attribute
+      //-   li: a(href='#dummy') Missing title attribute
+      //-   li: a(href='#dummy', title='') Empty title attribute
 
 
       p Double-check any links whose `href` is something questionable.

--- a/bundles/admin-ui/views/debug.jade
+++ b/bundles/admin-ui/views/debug.jade
@@ -24,26 +24,27 @@ block content
         p.debug-warning You have debug mode set to the 'warning' level. You will see all high and medium priority bugs.
         p.debug-all You have debug mode set to the 'all' level. You will see all bugs and general tips / suggestions.
 
-    p Enable debug mode to visually detect any improperly nested or potentially invalid markup, or any potentially inaccessible code.
+    p Enabling debug mode will load an additional stylesheet built to highlight HTML errors / semantic improvements.
       | It can be enabled via a variable in the admin bundle settings.styl file.
-    p
-      em Please note that this method of checking markup quality should not be relied upon entirely. Validate your markup!
+
+    p When enabled, the stylesheet will add a 'content' property to any highlighted element (excluding images) which is viewable in inspector / firebug. 
+      | This will give you a description of the highlighted error.
 
     section
       h2 General Bugs
 
-      p Are there any empty elements in your page?
+      p Check for empty elements.
 
       ul.inline-list.empty-elements
         li: a(href='#dummy', title='Link Title') Content In Here
         li: a(href='#dummy', title='Link Title')
 
-      p Avoid inline styles where possible.
+      p Avoid using inline styles.
 
       p
         a(href='#dummy', title='Link Title', style='color: #bada55; background-color: #444; padding: 5px 10px; display: inline-block;') I've got inline styles
 
-      p You should avoid using IDs for CSS, is this doing any styling?
+      p ID attributes should only be used for anchor tags to target, or for JavaScript functionality.
 
       a#link(href='#dummy', title='Link Title',) I've got an ID attribute
 
@@ -51,7 +52,7 @@ block content
     section
       h2 Images
 
-      p Images require `alt` attributes, empty `alt`s are fine but should be double-checked, no `alt` is bad and is flagged red.
+      p Images should all make use of the 'alt' attribute. If there is a reason to omit alt text for an image, still supply an empty alt='' attribute.
 
       p
         em As images do not accept the content property, no debug message will appear in the inspector.
@@ -64,22 +65,16 @@ block content
     section
       h2 Links
 
-      //- p Links sometimes, though not always, benefit from `title` attributes. Links without are never invalid but it’s a good idea to check.
-
-      //- ul.inline-list
-      //-   li: a(href='#dummy', title='Link Title') Good title attribute
-      //-   li: a(href='#dummy') Missing title attribute
-      //-   li: a(href='#dummy', title='') Empty title attribute
-
-
-      p Double-check any links whose `href` is something questionable.
+      p Check for links with empty, '#', or 'javascript' href attributes. Also check for the obsolete 'name' attribute.
 
       ul.inline-list
         li: a(href='http://google.com', title='Link Title') Good href attribute
+        li: a(href='', title='Link Title') Empty href attribute
         li: a(href='#', title='Link Title') Linking to #
         li: a(href='javascript:void(0)') JavaScript in the href attribute
+        li: a(href='http://google.com', name='name') Obsolete name attribute
 
-      p The `target` attribute ain’t too nice...
+      p Links shouldn't force new windows / tabs to open. Let the user decide.
       ul.inline-list
         li: a(href='http://google.com', title='Link Title') No target attribute
         li: a(href='http://google.com', title='Link Title', target='_blank') Opens in new window
@@ -88,7 +83,7 @@ block content
     section
       h2 Lists
 
-      p Ensure any lists only contain `li`s as children.
+      p Lists should only contain 'li' elements as direct children.
 
       ul.inline-list
         li
@@ -109,7 +104,7 @@ block content
 
     section
       h2 Tables
-      p It’s always nice to give `th`s `scope` attributes.
+      p Ensure every table heading has the correct 'scope' attribute.
 
       table
         thead
@@ -130,7 +125,7 @@ block content
             td Content
             td Content
 
-      p `tfoot` needs to come *before* `tbody`.
+      p When using a 'tfoot' element, place it before the 'tbody' element.
 
       table
         thead
@@ -161,7 +156,7 @@ block content
     section
       h2 Forms
 
-      p Forms require `action` attributes.
+      p All forms should have an 'action' attribute, which should not be left blank.
 
       form(method='_POST')
         .form-row
@@ -176,7 +171,7 @@ block content
           input.button(type='reset', value='Clear')
           input.button.button-primary(type='submit', value='Submit')
 
-      p Various form-field types have required attributes. `input`s need `type` attributes, `textarea`s need `rows` and `cols` attributes and submit buttons need a `value` attribute.
+      p Input elements should always have 'type' attributes, textareas should have 'rows' and 'cols' attributes and submit inputs should always have a 'value' attribute.
 
       form(action='#', method='_POST')
         .form-row

--- a/bundles/admin-ui/views/debug.jade
+++ b/bundles/admin-ui/views/debug.jade
@@ -1,0 +1,192 @@
+extend ../../admin/views/layout
+
+block content
+
+  //-
+  //- PAGE HEADER
+  //-
+  header.page-header
+
+    h1 Debug Mode
+
+    nav.breadcrumb
+      ul
+        li.nav-home: a(href='/admin') Home
+        li Admin UI
+
+    .notification.notification-error.debug-message-error
+      .notification-content
+        p You don't have debug mode enabled. Enable it in settings.styl to see the test results here.
+
+    .notification.notification-notice.debug-message
+      .notification-content
+        p.debug-error You have debug mode set to the 'error' level. You will only see the most important bugs.
+        p.debug-warning You have debug mode set to the 'warning' level. You will see all high and medium priority bugs.
+        p.debug-all You have debug mode set to the 'all' level. You will see all bugs and general tips / suggestions.
+
+    p Enable debug mode to visually detect any improperly nested or potentially invalid markup, or any potentially inaccessible code.
+      | It can be enabled via a variable in the admin bundle settings.styl file.
+    p
+      em Please note that this method of checking markup quality should not be relied upon entirely. Validate your markup!
+
+    section
+      h2 General Bugs
+
+      p Are there any empty elements in your page?
+
+      ul.inline-list.empty-elements
+        li: a(href='#dummy', title='Link Title') Content In Here
+        li: a(href='#dummy', title='Link Title')
+
+      p Avoid inline styles where possible.
+
+      p
+        a(href='#dummy', title='Link Title', style='color: #bada55; background-color: #444; padding: 5px 10px; display: inline-block;') I've got inline styles
+
+      p You should avoid using IDs for CSS, is this doing any styling?
+
+      a#link(href='#dummy', title='Link Title',) I've got an ID attribute
+
+
+    section
+      h2 Images
+
+      p Images require `alt` attributes, empty `alt`s are fine but should be double-checked, no `alt` is bad and is flagged red.
+
+      p
+        em As images do not accept the content property, no debug message will appear in the inspector.
+
+      ul.inline-list
+        li: img(src='http://dummyimage.com/150x80.png?text=Good alt attribute', alt='Alt text')
+        li: img(src='http://dummyimage.com/150x80.png?text=Empty alt attribute', alt='')
+        li: img(src='http://dummyimage.com/150x80.png?text=No alt attribute')
+
+    section
+      h2 Links
+
+      p Links sometimes, though not always, benefit from `title` attributes. Links without are never invalid but it’s a good idea to check.
+
+      ul.inline-list
+        li: a(href='#dummy', title='Link Title') Good title attribute
+        li: a(href='#dummy') Missing title attribute
+        li: a(href='#dummy', title='') Empty title attribute
+
+
+      p Double-check any links whose `href` is something questionable.
+
+      ul.inline-list
+        li: a(href='http://google.com', title='Link Title') Good href attribute
+        li: a(href='#', title='Link Title') Linking to #
+        li: a(href='javascript:void(0)') JavaScript in the href attribute
+
+      p The `target` attribute ain’t too nice...
+      ul.inline-list
+        li: a(href='http://google.com', title='Link Title') No target attribute
+        li: a(href='http://google.com', title='Link Title', target='_blank') Opens in new window
+
+
+    section
+      h2 Lists
+
+      p Ensure any lists only contain `li`s as children.
+
+      ul.inline-list
+        li
+          ul
+            li Good List
+            li Item 2
+            li Item 3
+            li Item 4
+            li Item 5
+        li
+          ul
+            li Bad List
+            li Item 2
+            li Item 3
+            a(href='http://google.com', title='Link Title') Link outside of an li
+            li Item 5
+
+
+    section
+      h2 Tables
+      p It’s always nice to give `th`s `scope` attributes.
+
+      table
+        thead
+          tr
+            th(scope='col') Heading
+            th(scope='col') Heading
+            th Heading (No Scope)
+            th(scope='col') Heading
+        tbody
+          tr
+            td Content
+            td Content
+            td Content
+            td Content
+          tr
+            td Content
+            td Content
+            td Content
+            td Content
+
+      p `tfoot` needs to come *before* `tbody`.
+
+      table
+        thead
+          tr
+            th(scope='col') Heading
+            th(scope='col') Heading
+            th(scope='col') Heading
+            th(scope='col') Heading
+        tbody
+          tr
+            td Content
+            td Content
+            td Content
+            td Content
+          tr
+            td Content
+            td Content
+            td Content
+            td Content
+        tfoot
+          tr
+            td Footer Content
+            td Footer Content
+            td Footer Content
+            td Footer Content
+
+
+    section
+      h2 Forms
+
+      p Forms require `action` attributes.
+
+      form(method='_POST')
+        .form-row
+          label
+            span.form-label-text Title
+            select
+              option Mr
+              option Miss
+              option Ms
+              option Mrs
+        .form-row.form-row-actions
+          input.button(type='reset', value='Clear')
+          input.button.button-primary(type='submit', value='Submit')
+
+      p Various form-field types have required attributes. `input`s need `type` attributes, `textarea`s need `rows` and `cols` attributes and submit buttons need a `value` attribute.
+
+      form(action='#', method='_POST')
+        .form-row
+          label
+            span.form-label-text Name
+            input.form-field(name='name')
+        .form-row
+          label
+            span.form-label-text Message
+            textarea.form-field
+        .form-row.form-row-actions
+          input.button(type='reset', value='Clear')
+          input.button.button-primary(type='submit')

--- a/bundles/admin-ui/views/sections/buttons.jade
+++ b/bundles/admin-ui/views/sections/buttons.jade
@@ -1,17 +1,17 @@
 h2 Buttons
 
 p
-  a.button(href='#') Standard
+  a.button(href='#buttons') Standard
   |  
-  a.button.button-primary(href='#') Primary
+  a.button.button-primary(href='#buttons') Primary
   |  
-  a.button.button-success(href='#') Success
+  a.button.button-success(href='#buttons') Success
   |  
-  a.button.button-notice(href='#') Notice
+  a.button.button-notice(href='#buttons') Notice
   |  
-  a.button.button-warning(href='#') Warning
+  a.button.button-warning(href='#buttons') Warning
   |  
-  a.button.button-error(href='#') Error
+  a.button.button-error(href='#buttons') Error
   |  
   button.button Button Element
   |  

--- a/bundles/admin-ui/views/sections/overlays.jade
+++ b/bundles/admin-ui/views/sections/overlays.jade
@@ -6,10 +6,10 @@ p Overlays use the
 
 p
   a(href='http://dummyimage.com/1000x700/47a967/fff.png', rel='fancybox-group')
-    img(src='http://dummyimage.com/120x70/47a967/fff.png')
+    img(src='http://dummyimage.com/120x70/47a967/fff.png', alt='Example Fancybox Gallery Image')
   a(href='http://dummyimage.com/600x900/4791a9/fff.png', rel='fancybox-group')
-    img(src='http://dummyimage.com/120x70/4791a9/fff.png')
+    img(src='http://dummyimage.com/120x70/4791a9/fff.png', alt='Example Fancybox Gallery Image')
   a(href='http://dummyimage.com/900x800/dc7f2a/fff.png', rel='fancybox-group')
-    img(src='http://dummyimage.com/120x70/dc7f2a/fff.png')
+    img(src='http://dummyimage.com/120x70/dc7f2a/fff.png', alt='Example Fancybox Gallery Image')
   a(href='http://dummyimage.com/1000x700/ca4427/fff.png', rel='fancybox-group')
-    img(src='http://dummyimage.com/120x70/ca4427/fff.png')
+    img(src='http://dummyimage.com/120x70/ca4427/fff.png', alt='Example Fancybox Gallery Image')

--- a/bundles/admin-ui/views/sections/pagination.jade
+++ b/bundles/admin-ui/views/sections/pagination.jade
@@ -14,23 +14,23 @@ h2 Pagination
   ul.pagination-list
 
     li.first
-      a(href='#', title='Go to the first page') First
+      a(href='#first', title='Go to the first page') First
     li.previous
-      a(href='#', title='Go to the previous page') Previous
+      a(href='#previous', title='Go to the previous page') Previous
     li
-      a(href='#', title='Go to page 1') 1
+      a(href='#page1', title='Go to page 1') 1
     li
-      a(href='#', title='Go to page 2') 2
+      a(href='#page2', title='Go to page 2') 2
     li
-      a.pagination-current-page(href='#', title='Go to page 3') 3
+      a.pagination-current-page(href='#page3', title='Go to page 3') 3
     li
-      a(href='#', title='Go to page 4') 4
+      a(href='#page4', title='Go to page 4') 4
     li
-      a(href='#', title='Go to page 5') 5
+      a(href='#page5', title='Go to page 5') 5
     li.next
-      a(href='#', title='Go to the next page') Next
+      a(href='#next', title='Go to the next page') Next
     li.last
-      a(href='#', title='Go to the last page') Last
+      a(href='#last', title='Go to the last page') Last
 
   ul.pagination-list
 

--- a/bundles/admin-ui/views/sections/tables.jade
+++ b/bundles/admin-ui/views/sections/tables.jade
@@ -3,12 +3,12 @@ h2 Tables
 table.table-highlight.table-sortable
   thead
     tr
-      th.sort-asc
-        a(href='#') ID
-      th
-        a(href='#') Name
-      th
-        a(href='#') Website
+      th(scope='col').sort-asc
+        a(href='#id') ID
+      th(scope='col')
+        a(href='#name') Name
+      th(scope='col')
+        a(href='#website') Website
   tbody
     tr
       td 001

--- a/bundles/admin/public/css/components/admin-ui.styl
+++ b/bundles/admin/public/css/components/admin-ui.styl
@@ -7,7 +7,6 @@
 
 .admin-ui
 
-
   //
   // GENERIC SECTIONS
   //
@@ -50,6 +49,55 @@
       padding 2px
       box-shadow 0px 1px 4px rgba(0,0,0,.4)
       display inline-block
+
+
+  //
+  // DEBUG PAGE
+  //
+
+  .inline-list
+    & > li
+      display inline-block
+      margin-right 30px
+      vertical-align top
+      list-style none
+
+  .empty-elements
+    a
+      display block
+      width 120px
+      height 40px
+      line-height 40px
+      background-color #CCC
+      text-align center
+
+
+  //
+  // DEBUG PAGE INTRO MESSAGE
+  //
+
+  .debug-message
+  .debug-message-error
+    display none
+
+  if $debugMode == false
+    .debug-message-error
+      display block
+  else
+    .debug-message
+      display block
+      p
+        display none
+
+      if $debugLevel == 'error'
+        .debug-error
+          display block
+      else if $debugLevel == 'warning'
+        .debug-warning
+          display block
+      else if $debugLevel == 'all'
+        .debug-all
+          display block
 
 
 //

--- a/bundles/admin/public/css/components/notification.styl
+++ b/bundles/admin/public/css/components/notification.styl
@@ -31,6 +31,8 @@
     overflow hidden
     background-position 0 -16px
     background-repeat no-repeat
+    background-color transparent
+    border 0
     background-image versionPath("/admin/images/content/sprite.png")
     .svg &
       background-image versionPath("/admin/images/content/sprite.svg")

--- a/bundles/admin/public/css/foundations/debug.styl
+++ b/bundles/admin/public/css/foundations/debug.styl
@@ -6,15 +6,10 @@
 //
 
 //
-// Enable this stylesheet to visually detect any improperly nested or
-// potentially invalid markup, or any potentially inaccessible code.
+// Enabling debug mode will load an additional stylesheet built to highlight
+// HTML errors / semantic improvements.
 //
-// Red          ==      definite error
-// Orange       ==      double-check
-// Blue         ==      should be fine but check anyway
-//
-// Please note that this method of checking markup quality should not be relied
-// upon entirely. Validate your markup!
+// Debug Mode can be enabled via a variable in the admin bundle settings.styl.
 //
 
 
@@ -49,26 +44,28 @@ debugStyle(message, outlineWidth, outlineColor)
 // GENERAL BUGS
 //
 
-// Are there any empty elements in your page?
-// Avoid special case where images report as being empty
+// Check for empty elements.
+// Avoid special case where images report as being empty.
 :not(img):not(input):not(textarea):empty
   debugWarning('Element is empty')
 
-// Avoid inline styles where possible.
+// Avoid using inline styles.
 [style]
-  debugWarning('Avoid inline styles wherever possible')
+  debugWarning('Avoid using inline styles')
 
-// You should avoid using IDs for CSS, is this doing any styling?
+// ID attributes should only be used for anchor tags to target, or for
+// JavaScript functionality.
 [id]
-  debugNotice('Avoid using IDs for CSS, is this doing any styling?')
+  debugNotice('Avoid using IDs for styling')
 
 
 //
 // IMAGES
 //
 
-// Images require `alt` attributes, empty `alt`s are fine but should be
-// double-checked, no `alt` is bad and is flagged red.
+// Images should all make use of the 'alt' attribute. If there is a reason to
+// omit alt text for an image, still supply an empty alt='' attribute.
+// Images do not accept the content property, so don't pass a message variable.
 img:not([alt])
   debugError()
 img[alt=""]
@@ -79,71 +76,74 @@ img[alt=""]
 // LINKS
 //
 
-// Links sometimes, though not always, benefit from `title` attributes. Links
-// without are never invalid but it’s a good idea to check.
-// a:not([title])
-//   debugNotice('Link missing title attribute')
-// a[title=""]
-//   debugNotice('Link has an empty title attribute')
-
-// Double-check any links whose `href` is something questionable.
-a[href="#"],
+// Check for links with empty, '#', or 'javascript' href attributes.
+// Also check for the obsolete 'name' attribute.
+a[href=""]
+  debugError('Empty href attribute')
+a[href="#"]
+  debugWarning('# as href attribute')
 a[href*="javascript"]
-  debugWarning('Questionable href attribute')
+  debugWarning('href contains javascript')
+a[name]
+  debugError('"Name" attribute is obsolete in HTML5')
 
-// The `target` attribute ain’t too nice...
+// Links shouldn't force new windows / tabs to open. Let the user decide.
 a[target]
-  debugWarning('Is the target attribute needed?')
+  debugWarning('Do not force links to open in new tabs/windows')
 
 
 //
 // LISTS
 //
 
-// Ensure any lists only contain `li`s as children.
+// Lists should only contain 'li' elements as direct children.
 ul,
 ol
   & > *:not(li)
-    debugError('Only li elements are are allowed as list children')
+    debugError('Lists should only contain "li" elements as direct children')
 
 
 //
 // TABLES
 //
 
-// It’s always nice to give `th`s `scope` attributes.
+// Ensure every table heading has the correct 'scope' attribute.
 th:not([scope])
-  debugNotice('th element should have a scope attribute')
+  debugNotice('table heading needs a "scope" attribute')
 
-// `tr`s as children of `table`s ain’t great, did you need a `thead`/`tbody`?
-// Browsers automatically insert missing `thead`/`tbody` elements so this test always passes.
-table > tr
-  debugNotice('Add a thead or tbody to this table')
+// Add thead or tbody elements where needed.
+// Browsers automatically insert missing 'thead' / 'tbody' elements so this test always passes.
+// table > tr
+//   debugNotice('Add a thead or tbody to this table')
 
-// `tfoot` needs to come *before* `tbody`.
+// When using a 'tfoot' element, place it before the 'tbody' element.
 tbody + tfoot
-  debugNotice('tfoot should appear before tbody')
+  debugNotice('Place the "tfoot" element before the "tbody"')
 
 
 //
 // FORMS
 //
 
-// Forms require `action` attributes
+// All forms should have an 'action' attribute, which should not be left blank.
 form:not([action])
-  debugError('Forms require `action` attributes')
+  debugError('All forms require an "action" attributes')
+form[action='']
+  debugError('The "action" attribute should not be blank')
 
-// Various form-field types have required attributes. `input`s need `type`
-// attributes, `textarea`s need `rows` and `cols` attributes and submit buttons
-// need a `value` attribute.
+// Input elements should always have 'type' attributes.
 input:not([type])
-  debugError('Inputs should have a type attribute')
+  debugError('Inputs should have a "type" attribute')
+
+// Textareas should have 'rows' and 'cols' attributes
 textarea:not([rows])
 textarea:not([cols])
-  debugError('Textareas require cols and rows attributes')
+  debugWarning('Textareas require "cols" and "rows" attributes')
+
+// Submit inputs should always have a 'value' attribute.
 input[type=submit]:not([value])
 input[type=submit][value=""]
-  debugError('Submit button needs a vlaue attribute')
+  debugError('Submit button needs a "value" attribute')
 
 
 //

--- a/bundles/admin/public/css/foundations/debug.styl
+++ b/bundles/admin/public/css/foundations/debug.styl
@@ -1,0 +1,140 @@
+//
+// DEBUG MODE
+// ==========
+// Based on the lovely idea implemented in inuit.css
+// https://github.com/csswizardry/inuit.css
+//
+
+//
+// Enable this stylesheet to visually detect any improperly nested or
+// potentially invalid markup, or any potentially inaccessible code.
+//
+// Red          ==      definite error
+// Orange       ==      double-check
+// Blue         ==      should be fine but check anyway
+//
+// Please note that this method of checking markup quality should not be relied
+// upon entirely. Validate your markup!
+//
+
+
+//
+// SETUP DEBUG STYLES
+//
+
+debugError(message = false)
+  if $debugLevel == 'error' || $debugLevel == 'warning' || $debugLevel == 'all'
+    debugStyle(message, 6px, $colorError)
+
+debugWarning(message = false)
+  if $debugLevel == 'warning' || $debugLevel == 'all'
+    debugStyle(message, 4px, $colorWarning)
+
+debugNotice(message = false)
+  if $debugLevel == 'notice' || $debugLevel == 'all'
+    debugStyle(message, 2px, $colorNotice)
+
+debugStyle(message, outlineWidth, outlineColor)
+  outline outlineWidth solid outlineColor
+  outline-offset (outlineWidth / -2)
+  if message
+    content message
+
+
+//
+// GENERAL BUGS
+//
+
+// Are there any empty elements in your page?
+// Avoid special case where images report as being empty
+:not(img):not(input):empty
+  debugWarning('Element is empty')
+
+// Avoid inline styles where possible.
+[style]
+  debugWarning('Avoid inline styles wherever possible')
+
+// You should avoid using IDs for CSS, is this doing any styling?
+[id]
+  debugNotice('Avoid using IDs for CSS, is this doing any styling?')
+
+
+//
+// IMAGES
+//
+
+// Images require `alt` attributes, empty `alt`s are fine but should be
+// double-checked, no `alt` is bad and is flagged red.
+img:not([alt])
+  debugError()
+img[alt=""]
+  debugWarning()
+
+
+//
+// LINKS
+//
+
+// Links sometimes, though not always, benefit from `title` attributes. Links
+// without are never invalid but it’s a good idea to check.
+a:not([title])
+  debugNotice('Link missing title attribute')
+a[title=""]
+  debugNotice('Link has an empty title attribute')
+
+// Double-check any links whose `href` is something questionable.
+a[href="#"],
+a[href*="javascript"]
+  debugWarning('Questionable href attribute')
+
+// The `target` attribute ain’t too nice...
+a[target]
+  debugWarning('Is the target attribute needed?')
+
+
+//
+// LISTS
+//
+
+// Ensure any lists only contain `li`s as children.
+ul,
+ol
+  & > *:not(li)
+    debugError('Only li elements are are allowed as list children')
+
+
+//
+// TABLES
+//
+
+// It’s always nice to give `th`s `scope` attributes.
+th:not([scope])
+  debugNotice('th element should have a scope attribute')
+
+// `tr`s as children of `table`s ain’t great, did you need a `thead`/`tbody`?
+// Browsers automatically insert missing `thead`/`tbody` elements so this test always passes.
+table > tr
+  debugNotice('Add a thead or tbody to this table')
+
+// `tfoot` needs to come *before* `tbody`.
+tbody + tfoot
+  debugNotice('tfoot should appear before tbody')
+
+
+//
+// FORMS
+//
+
+// Forms require `action` attributes
+form:not([action])
+  debugError('Forms require `action` attributes')
+
+// Various form-field types have required attributes. `input`s need `type`
+// attributes, `textarea`s need `rows` and `cols` attributes and submit buttons
+// need a `value` attribute.
+input:not([type])
+  debugError('Inputs should have a type attribute')
+textarea:not([rows][cols])
+  debugError('Textareas require cols and rows attributes')
+input[type=submit]:not([value])
+  debugError('Submit button needs a vlaue attribute')

--- a/bundles/admin/public/css/foundations/debug.styl
+++ b/bundles/admin/public/css/foundations/debug.styl
@@ -31,8 +31,12 @@ debugWarning(message = false)
     debugStyle(message, 4px, $colorWarning)
 
 debugNotice(message = false)
-  if $debugLevel == 'notice' || $debugLevel == 'all'
+  if $debugLevel == 'all'
     debugStyle(message, 2px, $colorNotice)
+
+debugAdditional(message = false)
+  if $debugLevel == 'error' || $debugLevel == 'warning' || $debugLevel == 'all'
+    debugStyle(message, 6px, purple)
 
 debugStyle(message, outlineWidth, outlineColor)
   outline outlineWidth solid outlineColor
@@ -47,7 +51,7 @@ debugStyle(message, outlineWidth, outlineColor)
 
 // Are there any empty elements in your page?
 // Avoid special case where images report as being empty
-:not(img):not(input):empty
+:not(img):not(input):not(textarea):empty
   debugWarning('Element is empty')
 
 // Avoid inline styles where possible.
@@ -77,10 +81,10 @@ img[alt=""]
 
 // Links sometimes, though not always, benefit from `title` attributes. Links
 // without are never invalid but it’s a good idea to check.
-a:not([title])
-  debugNotice('Link missing title attribute')
-a[title=""]
-  debugNotice('Link has an empty title attribute')
+// a:not([title])
+//   debugNotice('Link missing title attribute')
+// a[title=""]
+//   debugNotice('Link has an empty title attribute')
 
 // Double-check any links whose `href` is something questionable.
 a[href="#"],
@@ -134,7 +138,18 @@ form:not([action])
 // need a `value` attribute.
 input:not([type])
   debugError('Inputs should have a type attribute')
-textarea:not([rows][cols])
+textarea:not([rows])
+textarea:not([cols])
   debugError('Textareas require cols and rows attributes')
 input[type=submit]:not([value])
+input[type=submit][value=""]
   debugError('Submit button needs a vlaue attribute')
+
+
+//
+// ADDITIONAL CHECKS
+//
+
+// Check for variable misuse resulting in undefined classes
+[class*="undefined"]
+  debugAdditional('Class name of "undefined"')

--- a/bundles/admin/public/css/foundations/icons.styl
+++ b/bundles/admin/public/css/foundations/icons.styl
@@ -15,6 +15,10 @@
   .svg &
     background-image versionPath("/admin/images/content/sprite.svg")
 
+.icon-text-indent
+  text-indent 100%
+  white-space nowrap
+  overflow hidden
 
 //
 // STANDARD ICON SET
@@ -22,6 +26,7 @@
 
 .icon-reset
   @extend .icon-basic
+  @extend .icon-text-indent
   width 8px
   height 8px
   background-position -53px -25px

--- a/bundles/admin/public/css/index.css
+++ b/bundles/admin/public/css/index.css
@@ -101,6 +101,7 @@ td.title strong{font-size:1.05em}
 .table-sortable .sort-desc a:hover:after{background-position:-112px -15px}
 .icon-basic,.icon-reset,.icon-settings{display:inline-block;background-repeat:no-repeat;background-image:url("/admin/images/content/v0.1.0/sprite.png");}
 .svg .icon-basic,.svg .icon-reset,.svg .icon-settings{background-image:url("/admin/images/content/v0.1.0/sprite.svg")}
+.icon-text-indent,.icon-reset{text-indent:100%;white-space:nowrap;overflow:hidden}
 .icon-reset{width:8px;height:8px;background-position:-53px -25px}
 .button-reset:hover .icon-reset{background-position:-61px -25px}
 .icon-settings{position:absolute;top:50%;left:50%;margin-top:-8px;margin-left:-8px;width:16px;height:16px;text-indent:-9999px;overflow:hidden;background-position:-95px 0}
@@ -211,7 +212,7 @@ td.title strong{font-size:1.05em}
 .dialog-custom .controls{border-top:1px solid #ccc;padding:10px 10px;overflow:hidden;background-color:#fafafa;-webkit-box-shadow:0 3px 3px rgba(0,0,0,0.1);box-shadow:0 3px 3px rgba(0,0,0,0.1);-webkit-border-radius:0 0 3px 3px;border-radius:0 0 3px 3px;clear:left;}
 .dialog-custom .controls button{float:right;margin-left:10px}
 .notification{position:relative;padding:10px 14px;margin-bottom:20px;color:#fff;font-weight:bold;background-color:#bbb;border:1px solid rgba(0,0,0,0.1);-webkit-box-shadow:0 1px 1px rgba(255,255,255,0.3) inset,0 1px 3px rgba(0,0,0,0.1);box-shadow:0 1px 1px rgba(255,255,255,0.3) inset,0 1px 3px rgba(0,0,0,0.1);text-shadow:0 -1px 0 rgba(0,0,0,0.2);-webkit-border-radius:2px;border-radius:2px;}
-.notification .button-close{position:absolute;right:15px;top:15px;display:block;width:10px;height:11px;text-indent:-9999px;overflow:hidden;background-position:0 -16px;background-repeat:no-repeat;background-image:url("/admin/images/content/v0.1.0/sprite.png");}
+.notification .button-close{position:absolute;right:15px;top:15px;display:block;width:10px;height:11px;text-indent:-9999px;overflow:hidden;background-position:0 -16px;background-repeat:no-repeat;background-color:transparent;border:0;background-image:url("/admin/images/content/v0.1.0/sprite.png");}
 .svg .notification .button-close{background-image:url("/admin/images/content/v0.1.0/sprite.svg")}
 .notification .button-close:hover{background-position:-10px -16px}
 .notification-title{color:inherit;line-height:1.2;margin-bottom:0;}

--- a/bundles/admin/public/css/index.css
+++ b/bundles/admin/public/css/index.css
@@ -379,6 +379,10 @@ tr:hover .table-row-actions{opacity:1;-ms-filter:none;filter:none}
 .admin-ui section > h2{border-bottom:3px solid #bbb;padding-bottom:5px;margin-bottom:30px}
 .admin-ui section:target{margin-left:-18px;margin-right:-18px;padding-left:17px;padding-right:17px;border:1px solid transparent;-webkit-border-radius:5px;border-radius:5px;-webkit-animation-name:target-highlight;-moz-animation-name:target-highlight;-o-animation-name:target-highlight;-ms-animation-name:target-highlight;animation-name:target-highlight;-webkit-animation-duration:2s;-moz-animation-duration:2s;-o-animation-duration:2s;-ms-animation-duration:2s;animation-duration:2s;-webkit-animation-timing-function:ease-in-out;-moz-animation-timing-function:ease-in-out;-o-animation-timing-function:ease-in-out;-ms-animation-timing-function:ease-in-out;animation-timing-function:ease-in-out}
 .admin-ui #overlays a[rel='fancybox-group']{margin-right:10px;padding:2px;-webkit-box-shadow:0 1px 4px rgba(0,0,0,0.4);box-shadow:0 1px 4px rgba(0,0,0,0.4);display:inline-block}
+.admin-ui .inline-list > li{display:inline-block;margin-right:30px;vertical-align:top;list-style:none}
+.admin-ui .empty-elements a{display:block;width:120px;height:40px;line-height:40px;background-color:#ccc;text-align:center}
+.admin-ui .debug-message,.admin-ui .debug-message-error{display:none}
+.admin-ui .debug-message-error{display:block}
 @-moz-keyframes target-highlight{0%{background-color:rgba(48,103,143,0);border-color:rgba(48,103,143,0)}
 20%{background-color:rgba(48,103,143,0.2);border-color:rgba(48,103,143,0.4)}
 100%{background-color:rgba(48,103,143,0);border-color:rgba(48,103,143,0)}

--- a/bundles/admin/public/css/index.styl
+++ b/bundles/admin/public/css/index.styl
@@ -75,3 +75,11 @@
 
 @import 'components/admin-ui' // Move to admin-ui bundle
 @import 'sandbox'
+
+
+//
+// DEBUG MODE
+//
+
+if $debugMode
+  @import 'foundations/debug'

--- a/bundles/admin/public/css/settings.styl
+++ b/bundles/admin/public/css/settings.styl
@@ -7,6 +7,18 @@
 
 
 //
+// ENABLE DEBUG STYLING
+// Options are
+// * error: Only critical bugs are shown
+// * warning: Show error and warning bugs
+// * all: Show error and warning bugs, as well as general tips / minor bugs
+//
+
+$debugMode = false
+$debugLevel = 'all'
+
+
+//
 // LAYOUT
 //
 

--- a/bundles/admin/public/js/admin.js
+++ b/bundles/admin/public/js/admin.js
@@ -46,7 +46,8 @@ window.module('control-misc-ui', function (module) {
     );
 
     /** Notification Bars **/
-    $('.notification.close').append('<a class="button-close" href="#" />');
+    var notificationClose = $('<button />').addClass('button-close').text('Close')
+    $('.notification.close').append(notificationClose)
     $('.notification .button-close').click(function(e){
       $(this).parent('.notification').fadeTo(300, 0).slideUp(300);
       e.preventDefault();

--- a/bundles/admin/views/generic/form.jade
+++ b/bundles/admin/views/generic/form.jade
@@ -34,7 +34,7 @@ block content
       fieldset
         - if (typeof group.name !== 'undefined')
           h3=group.name
-        - if (typeof group.description !== 'undefined')
+        - if (typeof group.description !== 'undefined' || group.description !== '')
           p.group-description=group.description
         - each propertyMeta, key in group.properties
           - if (propertyMeta[formType])

--- a/bundles/admin/views/generic/includes/list-filter-form.jade
+++ b/bundles/admin/views/generic/includes/list-filter-form.jade
@@ -9,5 +9,5 @@
           - else
             input.form-field(type='text', value=url.Filter, name='Filter', placeholder="Filter Results")
             a.button-reset(href='?Reset', title='Reset Filter')
-              i.icon-reset
+              i.icon-reset Reset Filter
         input.button(type='submit',value='Filter')

--- a/bundles/admin/views/generic/list.jade
+++ b/bundles/admin/views/generic/list.jade
@@ -24,7 +24,7 @@ block content
     - if (dataSet.length === 0)
       p
         | No records found.
-      - if (adminIsAllowed(model.name, 'create')) 
+      - if (adminIsAllowed(model.name, 'create'))
         p Would you like to 
           a(href='/admin/#{model.slug}/new') add one
           | ?
@@ -43,7 +43,7 @@ block content
                       - directionClass = 'sort-asc'
                     - else if (url.Direction === 'desc')
                       - directionClass = 'sort-desc'
-                  th(class=directionClass)
+                  th(class=directionClass, scope='col')
                     a(href=querystring.getSort(url, key))=property
         tbody
           - each entity in dataSet
@@ -55,7 +55,7 @@ block content
                     - if (viewSchema.title === key)
                       td.title
                         strong: a(href='/admin/#{model.slug}/#{entity[model.idProperty]}')=propertyMeta.format(entityName)
-                        - if (adminIsAllowed(model.name, 'update')) 
+                        - if (adminIsAllowed(model.name, 'update'))
                           ul.table-row-actions
                             li: a(href='/admin/#{model.slug}/#{entity[model.idProperty]}/edit') Edit
                             li
@@ -69,7 +69,7 @@ block content
                             mixin displayImage(100, 100, entity[key][0], model.name + ' - ' + entityName, 'crop')
                       - else if (propertyMeta.type === 'link')
                         td
-                          a(href=entity[key], target='_blank')=entity[key]
+                          a(href=entity[key])=entity[key]
                       - else if (propertyMeta.type === 'dateTime')
                         td=dateTime(propertyMeta.format(entity[key]))
                       - else if (propertyMeta.type === 'groupedMultiselect')

--- a/bundles/admin/views/generic/view.jade
+++ b/bundles/admin/views/generic/view.jade
@@ -22,7 +22,7 @@ block content
     .panel-group
       - if (typeof group.name !== 'undefined')
         h3=group.name
-      - if (typeof group.description !== 'undefined')
+      - if (typeof group.description !== 'undefined' && group.description !== '')
         p.group-description=group.description
       dl
         - each propertyMeta, key in group.properties

--- a/bundles/admin/views/mixins/form-elements/checkbox-group.jade
+++ b/bundles/admin/views/mixins/form-elements/checkbox-group.jade
@@ -3,7 +3,9 @@
 //-
 
 mixin checkBoxGroupForObject(inputParams, params)
-  .form-row.form-row-field-group(class=params.errors[inputParams.name] && 'form-row-error')
+  .form-row.form-row-field-group(
+    class=params.errors[inputParams.name] !== undefined ? 'form-row-error ' : '')
+
     span.form-label-text #{params.label}
     ul.form-field
       - each option in params.list
@@ -15,14 +17,13 @@ mixin checkBoxGroupForObject(inputParams, params)
     mixin formRowDescription(params.information)
 
 
-// Where is this used? Would multiple single checboxes, or the above grouped
-// option be more applicable?
+//- Where is this used? Would multiple single checboxes, or the above grouped
+//- option be more applicable?
 mixin groupedCheckBoxGroupForObject(inputParams, params)
   fieldset
     h3=params.label
-    div(class=params.errors[inputParams.name] && 'form-row-error')
     - each options in params.groups
-      .form-row.form-row-field-group
+      .form-row.form-row-field-group(class=params.errors[inputParams.name] !== undefined ? 'form-row-error ' : '')
         span.form-label-text  #{options.label}
         -if (options.description !== undefined)
           strong=options.description

--- a/bundles/admin/views/mixins/form-elements/file.jade
+++ b/bundles/admin/views/mixins/form-elements/file.jade
@@ -8,7 +8,12 @@ mixin fileField(inputParams, params)
       span.form-label-text #{params.label}
         - if (params.required)
           abbr(title='#{ (params.required == true ? 'This field is required' : params.required) }') *
-      input.form-field(type='file', class=inputParams.class, name='#{inputParams.name}', multiple=params.multiple ? 'multiple' : '', value='#{inputParams.value || ''}')
+      input.form-field(
+        type='file',
+        class=(inputParams.class !== undefined ? inputParams.class : ''),
+        name='#{inputParams.name}',
+        multiple=params.multiple ? 'multiple' : '',
+        value='#{inputParams.value || ''}')
 
       mixin formRowErrorText(params.error)
     mixin formRowDescription(params.information)
@@ -32,15 +37,15 @@ mixin downloadLink(files, removeLink)
     table.image-summary.table-highlight
       thead
         tr
-          th Preview
-          th Image
+          th(scope='col') Preview
+          th(scope='col') Image
           - if (removeLink)
-            th.remove Remove
+            th.remove(scope='col') Remove
       tbody
         - each file in files
           tr
             td.thumbnail
-              mixin displayImage('100', '100', file, '', 'crop')
+              mixin displayImage('100', '100', file, file.basename, 'crop')
             td
               .file-summary
                 a.file-preview(rel='fancybox-group', href='/binary/#{file.path + file.basename}') #{file.basename}

--- a/bundles/admin/views/mixins/form-elements/select-elements.jade
+++ b/bundles/admin/views/mixins/form-elements/select-elements.jade
@@ -9,11 +9,20 @@ mixin selectField(inputParams, params)
         - if (params.required)
           abbr(title='#{ (params.required == true ? 'This field is required' : params.required) }') *
       - if (Array.isArray(params.list))
-        select.form-field(class=inputParams.class,name='#{inputParams.name}', multiple=(params.multiple ? 'multiple' : null ))
+
+        select.form-field(
+          class=(inputParams.class !== undefined ? inputParams.class : ''),
+          name='#{inputParams.name}',
+          multiple=(params.multiple ? 'multiple' : null ))
           - each option in params.list
             option(selected=(option == inputParams.value) ? 'selected' : null)=option
+
       - else
-        select.form-field(class=inputParams.class,name='#{inputParams.name}')
+
+        select.form-field(
+          class=(inputParams.class !== undefined ? inputParams.class : ''),
+          name='#{inputParams.name}')
+
           - each option, text in params.list
             option(selected=(option == inputParams.value) ? 'selected' : null, value=option)=text
 

--- a/bundles/admin/views/mixins/form-elements/textarea.jade
+++ b/bundles/admin/views/mixins/form-elements/textarea.jade
@@ -5,11 +5,19 @@
 mixin textboxField(inputParams, params)
   .form-row(
     class=(params.error !== undefined ? 'form-row-error ' : '') + (params.formRowClass !== undefined ? params.formRowClass : ''))
+
     label
       span.form-label-text #{params.label}
         - if (params.required)
           abbr(title='#{ (params.required == true ? 'This field is required' : params.required) }') *
-      textarea.form-field(name=inputParams.name, placeholder=inputParams.placeholder, class=inputParams.class, rows=(params.rows !== undefined ? params.rows : 4))=inputParams.value
+
+      textarea.form-field(
+          class=inputParams.class !== undefined ? inputParams.class : ''
+        , name=inputParams.name
+        , rows=params.rows !== undefined ? params.rows : 4
+        , placeholder=inputParams.placeholder
+        )= inputParams.value
+
       mixin formRowErrorText(params.error)
     mixin formRowDescription(params.information)
 


### PR DESCRIPTION
**Added a basic front-end 'Debug Mode'**
When enabled through a stylus variable in setting.styl, an extra stylesheet is included which visually highlights basic HTML errors / semantic improvements.

Tests currently include:
- Empty elements
- Inline Styles
- Missing alt / title attributes
- Links with blank or # href attributes
- Semantics checking for Forms, Tables and Links

**Added a debug demo page to Admin UI bundle**
Contains passing / failing examples for each test. When debug mode is enabled, these failing examples show the highlighting functionality.

**Fixed HTML markup**
Fixed HTML errors within Ctrl core, which were highlighted by the debug mode functionality.
